### PR TITLE
[Feature] 添加实体驼峰命名到数据库下划线命名的自动映射

### DIFF
--- a/src/Chloe/Annotations/CamelCaseToUnderscoreAttribute.cs
+++ b/src/Chloe/Annotations/CamelCaseToUnderscoreAttribute.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Chloe.Annotations
+{
+    /// <summary>
+    /// 驼峰命名与下划线命名映射
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public class CamelCaseToUnderscoreAttribute : Attribute
+    {
+        public CamelCaseToUnderscoreAttribute(bool mapTableName = true, string tablePrefix = "", string columnPrefix = "")
+        {
+            MapTableName = mapTableName;
+            TablePrefix = tablePrefix;
+            ColumnPrefix = columnPrefix;
+        }
+        /// <summary>
+        /// 是否映射表名
+        /// </summary>
+        public bool MapTableName { get; set; }
+        /// <summary>
+        /// 表名前缀
+        /// </summary>
+        public string TablePrefix { get; set; }
+        /// <summary>
+        /// 列名前缀
+        /// </summary>
+        public string ColumnPrefix { get; set; }
+    }
+}

--- a/src/Chloe/Entity/EntityNameConfig.cs
+++ b/src/Chloe/Entity/EntityNameConfig.cs
@@ -1,0 +1,59 @@
+﻿using Chloe.Annotations;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Reflection;
+
+namespace Chloe.Entity
+{
+    /// <summary>
+    /// 名称映射配置
+    /// </summary>
+    public class EntityNameConfig
+    {
+        public EntityNameConfig()
+        {
+
+        }
+        public EntityNameConfig(bool mapCamelCaseToUnderscore, bool mapTableName = true, string tablePrefix = "", string columnPrefix = "")
+        {
+            MapCamelCaseToUnderscore = mapCamelCaseToUnderscore;
+            MapTableName = mapTableName;
+            TablePrefix = tablePrefix;
+            ColumnPrefix = columnPrefix;
+        }
+        /// <summary>
+        /// 是否开启映射
+        /// </summary>
+        public bool MapCamelCaseToUnderscore { get; set; }
+        /// <summary>
+        /// 是否映射表名
+        /// </summary>
+        public bool MapTableName { get; set; }
+        /// <summary>
+        /// 表名前缀
+        /// </summary>
+        public string TablePrefix { get; set; }
+        /// <summary>
+        /// 列名前缀
+        /// </summary>
+        public string ColumnPrefix { get; set; }
+
+        public static EntityNameConfig Of(Type type)
+        {
+            var attribute = type.GetCustomAttribute(typeof(CamelCaseToUnderscoreAttribute)) as CamelCaseToUnderscoreAttribute;
+            if (attribute == null)
+            {
+                return new EntityNameConfig();
+            }
+
+            return new EntityNameConfig
+            {
+                MapCamelCaseToUnderscore = true,
+                ColumnPrefix = attribute.ColumnPrefix,
+                MapTableName = attribute.MapTableName,
+                TablePrefix = attribute.TablePrefix,
+            };
+        }
+    }
+}

--- a/src/Chloe/Entity/EntityType.cs
+++ b/src/Chloe/Entity/EntityType.cs
@@ -9,10 +9,14 @@ namespace Chloe.Entity
 {
     public class EntityType
     {
-        public EntityType(Type type)
+        public EntityType(Type type) : this(type, EntityNameConfig.Of(type))
+        {
+        }
+
+        public EntityType(Type type, EntityNameConfig config)
         {
             this.Type = type;
-            this.TableName = type.Name;
+            this.TableName = config.MapCamelCaseToUnderscore && config.MapTableName ? Utils.TranslateCamelCaseToUnderscore(type.Name, config.TablePrefix) : type.Name;
 
             PropertyInfo[] properties = this.Type.GetProperties(BindingFlags.Public | BindingFlags.Instance).Where(a => a.GetSetMethod() != null && a.GetGetMethod() != null).ToArray();
 
@@ -22,7 +26,7 @@ namespace Chloe.Entity
                 if (!MappingTypeSystem.IsMappingType(property.PropertyType, out mappingType))
                     continue;
 
-                PrimitiveProperty primitiveProperty = new PrimitiveProperty(property);
+                PrimitiveProperty primitiveProperty = new PrimitiveProperty(property, config);
                 primitiveProperty.DbType = mappingType.DbType;
                 primitiveProperty.IsNullable = property.PropertyType.CanNull();
 

--- a/src/Chloe/Entity/EntityTypeBuilder.cs
+++ b/src/Chloe/Entity/EntityTypeBuilder.cs
@@ -9,6 +9,12 @@ namespace Chloe.Entity
         {
             this.EntityType = new EntityType(typeof(TEntity));
         }
+
+        public EntityTypeBuilder(EntityNameConfig config)
+        {
+            this.EntityType = new EntityType(typeof(TEntity), config);
+        }
+
         public EntityType EntityType { get; private set; }
 
         IEntityTypeBuilder AsNonGenericBuilder()

--- a/src/Chloe/Entity/PrimitiveProperty.cs
+++ b/src/Chloe/Entity/PrimitiveProperty.cs
@@ -6,9 +6,9 @@ namespace Chloe.Entity
 {
     public class PrimitiveProperty : PropertyBase
     {
-        public PrimitiveProperty(PropertyInfo property) : base(property)
+        public PrimitiveProperty(PropertyInfo property, EntityNameConfig config) : base(property)
         {
-            this.ColumnName = property.Name;
+            this.ColumnName = config.MapCamelCaseToUnderscore ? Utils.TranslateCamelCaseToUnderscore(property.Name, config.ColumnPrefix) : property.Name;
         }
 
         public string ColumnName { get; set; }

--- a/src/Chloe/Utility/UtilConstants.cs
+++ b/src/Chloe/Utility/UtilConstants.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq.Expressions;
+using System.Text.RegularExpressions;
 
 namespace Chloe
 {
@@ -14,5 +15,7 @@ namespace Chloe
         public static readonly ConstantExpression Constant_False = Expression.Constant(false);
         public static readonly UnaryExpression Convert_TrueToNullable = Expression.Convert(Expression.Constant(true), typeof(Boolean?));
         public static readonly UnaryExpression Convert_FalseToNullable = Expression.Convert(Expression.Constant(false), typeof(Boolean?));
+
+        public static readonly Regex CamelCaseNameTranslateRegex = new Regex("[A-Z]");
     }
 }

--- a/src/Chloe/Utility/Utils.cs
+++ b/src/Chloe/Utility/Utils.cs
@@ -65,5 +65,10 @@ namespace Chloe
         {
             return t == typeof(Int16) || t == typeof(Int32) || t == typeof(Int64);
         }
+
+        public static string TranslateCamelCaseToUnderscore(string name, string prefix)
+        {
+            return prefix + UtilConstants.CamelCaseNameTranslateRegex.Replace(name, "_$0").TrimStart('_');
+        }
     }
 }

--- a/src/ChloeDemo/EntityMap.cs
+++ b/src/ChloeDemo/EntityMap.cs
@@ -13,7 +13,7 @@ namespace ChloeDemo
 {
     public class EntityMapBase<TEntity> : EntityTypeBuilder<TEntity> where TEntity : EntityBase
     {
-        public EntityMapBase()
+        public EntityMapBase() : base(new EntityNameConfig(true))
         {
             this.Property(a => a.Id).IsAutoIncrement().IsPrimaryKey();
         }
@@ -50,7 +50,7 @@ namespace ChloeDemo
 
     public class PersonExMap : EntityTypeBuilder<PersonEx>
     {
-        public PersonExMap()
+        public PersonExMap() : base(new EntityNameConfig(true))
         {
             this.MapTo("PersonEx");
             this.Property(a => a.Id).IsPrimaryKey().IsAutoIncrement(false);
@@ -85,7 +85,7 @@ namespace ChloeDemo
 
     public class TestEntityMap : EntityTypeBuilder<TestEntity>
     {
-        public TestEntityMap()
+        public TestEntityMap() : base(new EntityNameConfig(true, true, "sys_", "col_"))
         {
             this.Property(a => a.Id).IsAutoIncrement().IsPrimaryKey();
             this.HasQueryFilter(a => a.Id > 0);

--- a/src/ChloeDemo/Sharding/Order.cs
+++ b/src/ChloeDemo/Sharding/Order.cs
@@ -5,6 +5,7 @@ using System.Text;
 
 namespace ChloeDemo.Sharding
 {
+    [CamelCaseToUnderscore(false)]
     public class Order
     {
         [Column(IsPrimaryKey = true, Size = 50)]


### PR DESCRIPTION
在实际开发规范中，实体类及属性遵守大驼峰命名法，而数据库表名和列名常习惯使用下划线分隔命名。因此在这两者之间需要双向映射。

注意到Chloe提供了`Table`、`Column`特性标签，可以达到目的。但逐个字段添加略显繁琐，因此补充实现了`CamelCaseToUnderscore`类特性，”一键“开启映射功能。同时支持设置”只映射列名“，”表前缀“，”列前缀“等，满足个性化需要。

`CamelCaseToUnderscore`特性可以被`Table`、`Column`、`MapTo()`覆盖，由使用者自由选择。

Demo项目已测试在PostgreSql下正常运行。